### PR TITLE
Fixes armor and runtimes and cleans out chemwiz/technophreak code

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -385,8 +385,6 @@
 	item_state = "t45bpowerarmor"
 	armor = list("melee" = 75, "bullet" = 50, "laser" = 30, "energy" = 50, "bomb" = 48, "bio" = 60, "rad" = 50, "fire" = 75, "acid" = 0)
 
-// power armor
-
 /obj/item/clothing/suit/armor/f13/power_armor
 	w_class = WEIGHT_CLASS_HUGE
 	slowdown = 1
@@ -398,17 +396,11 @@
 	strip_delay = 200
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
-
-/obj/item/clothing/suit/armor/f13/power_armor/mob_can_equip(mob/user, slot)
-	if (ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if (!H.mind.istechnophreak && slot == SLOT_WEAR_SUIT)
-			H << "<span class='warning'>You don't have the proper training to operate the power armor!</span>"
-			return 0
-			..()
-	return ..()
-
-
+/obj/item/clothing/suit/armor/f13/power_armor/equipped(mob/user, slot)
+	if(user.mind && !user.mind.istechnophreak)
+		to_chat(user, "<span class='warning'>You don't have the proper training to operate the power armor!</span>")
+		return
+	else ..()
 
 /obj/item/clothing/suit/armor/f13/power_armor/t45d
 	name = "T-45d power armor"

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -22,7 +22,6 @@ Main doors: ACCESS_CAPTAIN 20
 	belt = 			/obj/item/storage/belt/military
 	glasses =		/obj/item/clothing/glasses/night
 	id = 			/obj/item/card/id/dogtag
-	technophreak = TRUE
 
 /datum/outfit/job/bos/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -133,7 +132,6 @@ Paladin
 	belt = 			/obj/item/storage/belt/utility/full/engi
 	backpack_contents = list(
 		/obj/item/kitchen/knife/combat=1)
-	chemwhiz = TRUE
 
 
 /*
@@ -206,7 +204,6 @@ Scribe
 		/obj/item/gun/energy/laser/pistol=1, \
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=2) //super paks not in yet
 	//PA training not in yet
-	chemwhiz = TRUE
 
 /*
 Initiate Knight
@@ -272,4 +269,3 @@ Initiate Scribe
 	id = 			/obj/item/card/id/dogtag
 	backpack_contents = list(
 		/obj/item/gun/energy/laser/pistol=1)
-	chemwhiz = TRUE

--- a/code/modules/jobs/job_types/den.dm
+++ b/code/modules/jobs/job_types/den.dm
@@ -220,7 +220,6 @@ Den Doctor
 	outfit = /datum/outfit/job/den/f13dendoc
 
 /datum/outfit/job/den/f13dendoc
-	chemwhiz = TRUE 
 	name = "Den Doctor"
 	jobtype = /datum/job/den/f13dendoc
 	uniform =  		/obj/item/clothing/under/f13/medic

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -57,8 +57,6 @@ Medic
 /datum/outfit/job/enclave/f13usmedic
 	name = "US Medic"
 	jobtype = /datum/job/enclave/f13usmedic
-	chemwhiz = TRUE
-
 	id = /obj/item/card/id/gold
 	uniform =  /obj/item/clothing/under/rank/captain
 

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -177,10 +177,6 @@
 
 	var/pda_slot = SLOT_BELT
 
-	var/technophreak = FALSE //F13 Technophreak, for super advanced tech (e.g. power armor, R&D)
-	var/chemwhiz = FALSE //F13 Chemwhiz, for chemistry machines
-
-
 /datum/outfit/job/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	switch(H.backbag)
 		if(GBACKPACK)
@@ -203,11 +199,6 @@
 			backpack_contents = list()
 		backpack_contents.Insert(1, box) // Box always takes a first slot in backpack
 		backpack_contents[box] = 1
-
-	if(technophreak==TRUE)
-		H.mind.istechnophreak = TRUE
-	if(chemwhiz == TRUE)
-		H.mind.ischemwhiz = TRUE
 
 /datum/outfit/job/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)
@@ -241,11 +232,6 @@
 		PDA.owner = H.real_name
 		PDA.ownjob = J.title
 		PDA.update_label()
-
-	if(technophreak==TRUE)
-		H.mind.istechnophreak = TRUE
-	if(chemwhiz == TRUE)
-		H.mind.ischemwhiz = TRUE
 
 /datum/outfit/job/get_chameleon_disguise_info()
 	var/list/types = ..()

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -140,7 +140,6 @@ Medic
 	outfit = /datum/outfit/job/ncr/f13medic
 
 /datum/outfit/job/ncr/f13medic
-	chemwhiz = TRUE
 	name = "NCR Medical Officer"
 	jobtype = /datum/job/ncr/f13medic
 	uniform =  		/obj/item/clothing/under/f13/ncr/officer

--- a/code/modules/jobs/job_types/vault.dm
+++ b/code/modules/jobs/job_types/vault.dm
@@ -159,7 +159,6 @@ Medical Doctor
 /datum/outfit/job/vault/f13doctor
 	name = "Medical Doctor"
 	jobtype = /datum/job/vault/f13doctor
-	chemwhiz = TRUE
 
 	//pda
 	uniform = 		/obj/item/clothing/under/f13/vault13
@@ -198,7 +197,6 @@ Scientist
 /datum/outfit/job/vault/f13vaultscientist
 	name = "Scientist"
 	jobtype = /datum/job/vault/f13vaultscientist
-	chemwhiz = TRUE
 
 	//pda
 	uniform = 		/obj/item/clothing/under/f13/vault13

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -237,8 +237,6 @@ Pusher
 	suit = /obj/item/clothing/suit/armor/khan
 	uniform = /obj/item/clothing/under/f13/khan
 
-	chemwhiz = TRUE
-
 /datum/outfit/job/wasteland/f13pusher/pre_equip(mob/living/carbon/human/H)
 	..()
 	r_pocket = pick(


### PR DESCRIPTION
Currently we have like six ways to handle equipping something;
mob_can_equip
equip_to_slot_if_possible
equip_to_slot
equip_to_appropriate_slot
equip_to_slot_or_del
equipped
and there might actually be others
equipped is what's used in /obj/item/clothing at this time
I'm not sure which one is better, probably proc/equipped as it uses LAZYLEN, and DEFINITELY not mob_can_equip, because that broke everything.

<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:
